### PR TITLE
Fix up some melee dps calculations+ consider target armor

### DIFF
--- a/Source/SimpleSidearms/intercepts/Intercepts_Verbs.cs
+++ b/Source/SimpleSidearms/intercepts/Intercepts_Verbs.cs
@@ -55,10 +55,15 @@ namespace SimpleSidearms.intercepts
             object fieldValue = field.GetValue(__instance);
             if (fieldValue != null && fieldValue is LocalTargetInfo)
             {
-                Thing targetThing = ((LocalTargetInfo)fieldValue).Thing;
-                if (__instance.CasterPawn != null && targetThing != null && targetThing is Pawn && !(targetThing as Pawn).Dead && (targetThing as Pawn).equipment != null)
+                Thing target = ((LocalTargetInfo)fieldValue).Thing;
+                Pawn caster = __instance.CasterPawn;
+                if (caster != null && target != null && target is Pawn && !(target as Pawn).Dead && (target as Pawn).equipment != null)
                 {
-                    WeaponAssingment.doCQC(targetThing as Pawn, __instance.CasterPawn);
+                    WeaponAssingment.doCQC(target as Pawn, caster);
+                }
+                if (caster != null && target != null && target is Pawn && !caster.Dead)
+                {
+                    WeaponAssingment.doCQCOnAttack(caster, target as Pawn);
                 }
             }
         }

--- a/Source/SimpleSidearms/utilities/GettersFilters.cs
+++ b/Source/SimpleSidearms/utilities/GettersFilters.cs
@@ -253,13 +253,14 @@ namespace SimpleSidearms.utilities
             return best as ThingWithComps;
         }
 
-        internal static ThingWithComps findBestMeleeWeapon(Pawn pawn, bool skipDangerous, out bool unarmedIsBetter/*, SelectionMode mode*/)
+        internal static ThingWithComps findBestMeleeWeapon(Pawn pawn, bool skipDangerous/*, SelectionMode mode*/, Pawn target)
         {
             List<Thing> weapons = getWeaponsOfType(pawn, WeaponSearchType.Melee);
 
-            float bestSoFar = float.MinValue;
-            Thing best = null;
-
+            Thing best = pawn.equipment.Primary;
+            float bestSoFar = best == null ? float.MinValue :
+                StatCalculator.MeleeDPS(pawn, best as ThingWithComps, SpeedSelectionBiasMelee.Value, target);
+            
             foreach (Thing thing in weapons)
             {
                 if (!(thing is ThingWithComps))
@@ -271,7 +272,7 @@ namespace SimpleSidearms.utilities
 
                 float dpsAvg = -1f;
 
-                dpsAvg = StatCalculator.MeleeDPS(pawn, thing as ThingWithComps, SpeedSelectionBiasMelee.Value);
+                dpsAvg = StatCalculator.MeleeDPS(pawn, thing as ThingWithComps, SpeedSelectionBiasMelee.Value, target);
 
                 if (dpsAvg > bestSoFar)
                 {
@@ -280,7 +281,8 @@ namespace SimpleSidearms.utilities
                 }
             }
 
-            unarmedIsBetter = StatCalculator.UnarmedDPS(pawn, SpeedSelectionBiasMelee.Value) > bestSoFar;
+            if (StatCalculator.MeleeDPS(pawn, null, SpeedSelectionBiasMelee.Value, target) > bestSoFar)
+                best = null;
 
             return best as ThingWithComps;
         }


### PR DESCRIPTION
The code before was finding a weapons first attack, which was often a blunt jab instead of the main attack.

This should also mean unarmed is not used much - fixing Issue #6

But the main reason I'm here - This adds the ability to swap between melee weapons based on the armor of the target. This includes keeping a ranged weapon if its still better DPS. Triggers when you attack. It could use some short-term memory to Not re-calculate every attack - somehow remember your current target.