### PR TITLE
Fix for attempting to drop a chunk

### DIFF
--- a/Source/SimpleSidearms/intercepts/Intercepts_UI.cs
+++ b/Source/SimpleSidearms/intercepts/Intercepts_UI.cs
@@ -18,9 +18,9 @@ namespace SimpleSidearms.intercepts
         [HarmonyPrefix]
         private static void InterfaceDrop(ITab_Pawn_Gear __instance, Thing t)
         {
-            ThingWithComps thingWithComps = t as ThingWithComps;
-            if (thingWithComps.def.IsMeleeWeapon || thingWithComps.def.IsRangedWeapon)
+            if (t.def.IsMeleeWeapon || t.def.IsRangedWeapon)
             {
+                ThingWithComps thingWithComps = t as ThingWithComps;
                 ThingOwner thingOwner = thingWithComps.holdingOwner;
                 IThingHolder actualOwner = thingOwner.Owner;
                 if (actualOwner is Pawn_InventoryTracker)


### PR DESCRIPTION
As chunks don't fall into the ThingWithComps category, Simple sidearms would error when attempting to drop a chunk. Pawns can pick up chunks when on a caravan incident map, when using Pick Up and Haul, or with Combat Extended.