### PR TITLE
Fixed a bug which broke the caravan trade/split/item(etc.) window when using "HideSidearmsInCaravanDialogs"

### DIFF
--- a/Source/intercepts/Intercepts_Caravan.cs
+++ b/Source/intercepts/Intercepts_Caravan.cs
@@ -364,7 +364,7 @@ namespace PeteTimesSix.SimpleSidearms.Intercepts
                     if (rememberedNonEquippedCount.ContainsKey(weapon))
                         rememberedNonEquippedCount[weapon]++;
                     else
-                        rememberedNonEquippedCount[weapon] = 1;
+                        rememberedNonEquippedCount.Add(weapon, 1);
                 }
             }
 
@@ -383,6 +383,7 @@ namespace PeteTimesSix.SimpleSidearms.Intercepts
                 if (thing.TryGetComp<CompBiocodable>() is CompBiocodable biocode 
                     && biocode.Biocoded 
                     && biocode.CodedPawn is Pawn pawn
+                    && pawn.IsColonist
                     && pawns.Contains(pawn))
                 {
                     // if the pawn whom this weapon is biocoded to remembers this weapon, remove it from the output


### PR DESCRIPTION
Fixed a bug where the caravan trade/split/item etc. window would break if there is a non-colonist (e.g. prisoner) with a remembered biocoded weapon in the caravan.

One line of code, but the whole window content would not display - should be fixed now.

(Only reason I changed the dictionary ".Add" line is to stop myself from thinking that that is an error, it works fine both ways.)